### PR TITLE
Fix login page serving

### DIFF
--- a/server.js
+++ b/server.js
@@ -38,16 +38,12 @@ app.use(helmet());
 app.use(rateLimit({ windowMs: 15 * 60 * 1000, max: 100 }));
 
 // Sau khi app = express();
-app.use(express.static(path.join(__dirname, 'public')));
-
-
 // Serve static files
 app.use(express.static(path.join(__dirname, 'public')));
 
-// Khi truy cập root, redirect về login form
+// Khi truy cập root, luôn trả về trang đăng nhập
 app.get('/', (req, res) => {
-  // res.redirect('/SignUp_LogIn_Form.html');
-    res.redirect('/index.html');
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
 


### PR DESCRIPTION
## Summary
- serve `index.html` directly for root requests
- remove redundant static middleware

## Testing
- `npm start` *(fails: OAuth2Strategy requires a clientID option)*

------
https://chatgpt.com/codex/tasks/task_b_6862b6ba10a8833097a5c9814b09127f